### PR TITLE
Fix relative path on static_machine

### DIFF
--- a/src/acorn/static_machine.cr
+++ b/src/acorn/static_machine.cr
@@ -31,7 +31,7 @@ module Acorn
       @table ||= Acorn::TransitionTable.new(grammar: self)
     end
 
-    ECR.def_to_s "./src/acorn/static_machine/template.ecr"
+    ECR.def_to_s "#{__DIR__}/static_machine/template.ecr"
 
     def to_outfile(outfile)
       File.write(outfile, to_s)


### PR DESCRIPTION
Fix relative path on _static_machine_

Just for does not raise this error.

```shell
crystal run src/my-parser.cr 
Error opening file './src/acorn/static_machine/template.ecr' with mode 'r': No such file or directory (Errno)
```